### PR TITLE
fix: rework commands api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
         - yarn test
     - stage: prerelease
       node_js: 10
-      if: branch = master
+      if: (NOT type IN (pull_request)) AND (branch = master)
       script:
         - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
         - yarn pre-release

--- a/examples/with-local-config/spire-config.js
+++ b/examples/with-local-config/spire-config.js
@@ -1,19 +1,9 @@
 module.exports = () => ({
   plugins: [
-    function ping({ setCommand, getCommand }) {
-      const command = Symbol.for('ping');
+    function ping() {
       return {
-        async setup({ cli }) {
-          cli.command(
-            'ping',
-            'replies with pong',
-            () => {},
-            () => setCommand(command)
-          );
-        },
-        async skip() {
-          return getCommand() !== command;
-        },
+        command: 'ping',
+        description: 'replies with pong',
         async run({ logger }) {
           logger.log('pong');
         },

--- a/packages/spire-plugin-clean/index.js
+++ b/packages/spire-plugin-clean/index.js
@@ -1,7 +1,7 @@
 const execa = require('execa');
 
 function clean(
-  { setState, getState, setCommand, getCommand },
+  { setState, getState },
   {
     command = 'clean',
     keep = [
@@ -13,16 +13,11 @@ function clean(
     ],
   }
 ) {
-  const CLEAN_COMMAND = Symbol.for(command);
   return {
     name: 'spire-plugin-clean',
-    async setup({ cli }) {
-      cli.command(
-        command,
-        'remove files with git clean',
-        () => {},
-        () => setCommand(CLEAN_COMMAND)
-      );
+    command: command,
+    description: 'cleanup using git-clean',
+    async setup() {
       setState({
         gitCleanArgs: [
           '-X',
@@ -34,9 +29,6 @@ function clean(
           ),
         ],
       });
-    },
-    async skip() {
-      return getCommand() !== CLEAN_COMMAND;
     },
     async run({ options, logger, cwd }) {
       const { gitCleanArgs } = getState();

--- a/packages/spire-plugin-eslint/index.js
+++ b/packages/spire-plugin-eslint/index.js
@@ -2,7 +2,7 @@ const execa = require('execa');
 const SpireError = require('spire/error');
 
 function eslint(
-  { setCommand, getCommand, setState, getState, hasFile, hasPackageProp },
+  { setState, getState, hasFile, hasPackageProp },
   {
     command = 'lint',
     config: defaultEslintConfig = require.resolve('spire-plugin-eslint/config'),
@@ -12,16 +12,11 @@ function eslint(
     glob = '*.js',
   }
 ) {
-  const LINT_COMMAND = Symbol.for(command);
   return {
     name: 'spire-plugin-eslint',
+    command,
+    description: 'lint files with ESLint',
     async setup({ cli, argv }) {
-      cli.command(
-        command,
-        'lint files with ESLint',
-        () => {},
-        () => setCommand(LINT_COMMAND)
-      );
       const hasCustomConfig =
         argv.includes('--config') ||
         (await hasFile('.eslintrc')) ||
@@ -63,9 +58,6 @@ function eslint(
           { [glob]: ['eslint', ...prev.eslintArgs, '--fix'] },
         ],
       }));
-    },
-    async skip() {
-      return getCommand() !== LINT_COMMAND;
     },
     async run({ options, logger, cwd }) {
       const { eslintArgs } = getState();

--- a/packages/spire-plugin-jest/index.js
+++ b/packages/spire-plugin-jest/index.js
@@ -2,7 +2,7 @@ const execa = require('execa');
 const SpireError = require('spire/error');
 
 function jest(
-  { setCommand, getCommand, setState, getState, hasFile, hasPackageProp },
+  { setState, getState, hasFile, hasPackageProp },
   {
     command = 'test',
     config: defaultJestConfig = require.resolve(
@@ -12,16 +12,11 @@ function jest(
     glob = '*.js',
   }
 ) {
-  const TEST_COMMAND = Symbol.for(command);
   return {
     name: 'spire-plugin-jest',
+    command,
+    description: 'run tests with Jest',
     async setup({ cli }) {
-      cli.command(
-        command,
-        'run tests with Jest',
-        () => {},
-        () => setCommand(TEST_COMMAND)
-      );
       const hasCustomConfig =
         (await hasFile('jest.config.js')) ||
         (await hasFile('jest.config.json')) ||
@@ -49,9 +44,6 @@ function jest(
           },
         ],
       }));
-    },
-    async skip() {
-      return getCommand() !== TEST_COMMAND;
     },
     async run({ options, logger, cwd }) {
       const { jestArgs } = getState();

--- a/packages/spire-plugin-lerna-release/index.js
+++ b/packages/spire-plugin-lerna-release/index.js
@@ -1,7 +1,7 @@
 const execa = require('execa');
 
 function lernaRelease(
-  { setCommand, getCommand, setState, getState },
+  { setState, getState },
   {
     command = 'release',
     gitAuthorName = undefined,
@@ -11,16 +11,11 @@ function lernaRelease(
     extraArgs = [],
   }
 ) {
-  const RELEASE_COMMAND = Symbol.for(`lerna-${command}`);
   return {
     name: 'spire-plugin-lerna-release',
-    async setup({ cli }) {
-      cli.command(
-        command,
-        'run lerna publish',
-        () => {},
-        () => setCommand(RELEASE_COMMAND)
-      );
+    command,
+    description: 'run lerna publish',
+    async setup() {
       setState({
         lernaPublishArgs: [
           '--conventional-commits',
@@ -32,9 +27,6 @@ function lernaRelease(
           ...extraArgs,
         ],
       });
-    },
-    async skip() {
-      return getCommand() !== RELEASE_COMMAND;
     },
     async run({ options, cwd, logger }) {
       const { lernaPublishArgs } = getState();

--- a/packages/spire-plugin-prettier/index.js
+++ b/packages/spire-plugin-prettier/index.js
@@ -2,7 +2,7 @@ const execa = require('execa');
 const SpireError = require('spire/error');
 
 function prettier(
-  { hasFile, hasPackageProp, setCommand, getCommand, setState, getState },
+  { hasFile, hasPackageProp, setState, getState },
   {
     command = 'format',
     config: defaultPrettierConfig = require.resolve(
@@ -14,16 +14,11 @@ function prettier(
     glob = '**/*.+(js|json|less|css|ts|tsx|md)',
   }
 ) {
-  const FORMAT_COMMAND = Symbol.for(command);
   return {
     name: 'spire-plugin-prettier',
-    async setup({ argv, cli }) {
-      cli.command(
-        command,
-        'format files with Prettier',
-        () => {},
-        () => setCommand(FORMAT_COMMAND)
-      );
+    command,
+    description: 'format files with Prettier',
+    async setup({ argv }) {
       const hasCustomConfig =
         (await hasFile('.prettierrc')) ||
         (await hasFile('.prettierrc.js')) ||
@@ -65,9 +60,6 @@ function prettier(
           { [glob]: ['prettier', ...prev.prettierArgs] },
         ],
       }));
-    },
-    async skip() {
-      return getCommand() !== FORMAT_COMMAND;
     },
     async run({ options, logger, cwd }) {
       const { prettierArgs } = getState();

--- a/packages/spire-plugin-semantic-release/index.js
+++ b/packages/spire-plugin-semantic-release/index.js
@@ -2,7 +2,7 @@ const execa = require('execa');
 const SpireError = require('spire/error');
 
 function semanticRelease(
-  { setCommand, getCommand, setState, getState, hasFile, hasPackageProp },
+  { setState, getState, hasFile, hasPackageProp },
   {
     command = 'release',
     config: defaultSemanticReleaseConfig = require.resolve(
@@ -14,16 +14,11 @@ function semanticRelease(
     gitAuthorEmail = undefined,
   }
 ) {
-  const RELEASE_COMMAND = Symbol.for(command);
   return {
     name: 'spire-plugin-semantic-release',
-    async setup({ cli }) {
-      cli.command(
-        command,
-        'run semantic-release',
-        () => {},
-        () => setCommand(RELEASE_COMMAND)
-      );
+    command,
+    description: 'run semantic-release',
+    async setup() {
       const hasCustomConfig =
         (await hasFile('release.config.js')) ||
         (await hasFile('.releaserc')) ||
@@ -41,9 +36,6 @@ function semanticRelease(
           `Custom semantic-release config is not allowed, using ${defaultSemanticReleaseConfig} instead`
         );
       }
-    },
-    async skip() {
-      return getCommand() !== RELEASE_COMMAND;
     },
     async run({ options, cwd, logger }) {
       const { semanticReleaseArgs } = getState();

--- a/packages/spire/README.md
+++ b/packages/spire/README.md
@@ -5,7 +5,6 @@ Extensible JavaScript toolbox management.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Motivation](#motivation)
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
@@ -196,6 +195,9 @@ _Note: It is recommended to keep plugins scoped to a single feature or tool._
   - `options` \<[Object]\> User-provided plugin options.
 - returns: \<[Object]\>
   - `name` \<[string]\> Name of the plugin (recommended).
+  - `command` \<[string]\> Optional name of command. Leaving it empty will
+    ignore `run` hook completly.
+  - `description` \<[string]\> Optional human-readable command description.
   - `preinstall` \<[function]\([Context]\): [Promise]\> Executed before
     `yarn install` or `npm install`
   - `postinstall` \<[function]\([Context]\): [Promise]\> Executed after
@@ -205,9 +207,6 @@ _Note: It is recommended to keep plugins scoped to a single feature or tool._
   - `setup` \<[function]\([Context]\): [Promise]\> Executed before `run` hook.
     Use it to prepare arguments or config for your tools. If it fails, Spire
     stops futher hooks from being executed.
-  - `skip` \<[function]\([Context]\): [Promise]<[boolean]>\> Executed before
-    `run` hook. Returning `true` will prevent `run` hook from being executed.
-    Use this to check if the current command is the one you expect
   - `run` \<[function]\([Context]\): [Promise]\> Executed as the main logic of
     the plugin. Use this hook to run the CLI tool or process long-running task.
   - `teardown` \<[function]\([Context]\): [Promise]\> Executed after `run` hook,
@@ -223,17 +222,8 @@ module.exports = (spire, options) => {
   const MY_TOOL = Symbol.for('my-tool');
   return {
     name: 'my-awesome-tool',
-    async setup({ cli }) {
-      cli.command(
-        'my-tool',
-        'run my awesome tool',
-        () => {},
-        () => spire.setCommand(MY_TOOL)
-      );
-    },
-    async skip() {
-      return spire.getCommand() !== MY_TOOL;
-    },
+    command: 'my-tool',
+    description: 'run my awesome tool',
     async run({ logger }) {
       logger.log('Hi from my awesome tool!');
     },
@@ -318,15 +308,10 @@ plugins.
       recevies the previous state and returns an object. Usefull to avoid
       `getState()` calls.
   - `getState` \<[function]\(\): [Object]\> Returns current state.
-  - `setCommand` \<[function]\([Symbol]\)\> Sets or overrides current command.
-  - `getCommand` \<[function]\(\): [Symbol]\> Returns current command name if
-    any. Available only after `setup` hook.
   - `hasFile` \<[function]\([string]\): [Promise]\<[boolean]\>\> Checks if
     current projects contains specific file.
   - `hasPackageProp` \<[function]\([string]\): [Promise]\<[boolean]\>\> Check if
     current project's `package.json` contains specific prop.
-  - `stop` \<[function]\(\)\> Stops futher `run` hooks from being executed.
-    Works only in plugins.
 
 ### `context`
 

--- a/packages/spire/lib/create-cli.js
+++ b/packages/spire/lib/create-cli.js
@@ -1,5 +1,8 @@
 const yargs = require('yargs');
 
+/**
+ * @returns {import('yargs').Argv}
+ */
 function createCli() {
   return yargs
     .parserConfiguration({

--- a/packages/spire/lib/create-core.js
+++ b/packages/spire/lib/create-core.js
@@ -5,15 +5,6 @@ function createCore({ cwd }, { setState, getState }) {
   return {
     setState,
     getState,
-    stop() {
-      return setState({ stopped: true });
-    },
-    getCommand() {
-      return getState().command;
-    },
-    setCommand(command) {
-      return setState({ command });
-    },
     // Check if project contains specific file
     async hasFile(file) {
       return await pathExists(join(cwd, file));

--- a/packages/spire/lib/create-state.js
+++ b/packages/spire/lib/create-state.js
@@ -1,10 +1,4 @@
-function createState(
-  initialState = {
-    stopped: false,
-    command: null,
-    linters: [],
-  }
-) {
+function createState(initialState = { linters: [] }) {
   let state = initialState;
   return {
     getState() {

--- a/packages/spire/lib/plugins/hook.js
+++ b/packages/spire/lib/plugins/hook.js
@@ -1,6 +1,7 @@
 const prettyFormat = require('pretty-format');
 
-function hook({ setCommand, getCommand, getState }) {
+function hook({ getState }) {
+  let hookToExecute;
   return {
     name: 'spire-hook-support',
     async setup({ cli }) {
@@ -20,22 +21,22 @@ function hook({ setCommand, getCommand, getState }) {
             type: 'string',
           });
         },
-        argv => setCommand(Symbol.for(argv.name))
+        argv => {
+          hookToExecute = argv.name;
+        }
       );
     },
     async teardown(context) {
-      const command = getCommand();
-      switch (command) {
-        case Symbol.for('preinstall'):
-        case Symbol.for('postinstall'):
-        case Symbol.for('preuninstall'):
-        case Symbol.for('precommit'):
-        case Symbol.for('postmerge'): {
-          const hook = Symbol.keyFor(command);
+      switch (hookToExecute) {
+        case 'preinstall':
+        case 'postinstall':
+        case 'preuninstall':
+        case 'precommit':
+        case 'postmerge': {
           for (const plugin of context.config.plugins) {
-            if (plugin[hook]) {
-              context.logger.debug(`Running ${plugin.name}.${hook}`);
-              await plugin[hook](context);
+            if (plugin[hookToExecute]) {
+              context.logger.debug(`Running ${plugin.name}.${hookToExecute}`);
+              await plugin[hookToExecute](context);
             }
           }
         }


### PR DESCRIPTION
This change simplifies way of adding a custom command within the plugin.

Before:
* Const: It required each plugin to keep track of current command on its own
* Cons: It had a dependency on internal `cli` yargs instance
* Pros: Allowed to add multiple commands

After:
* Pros: New `command` property is the only thing needed to add a custom command
* Pros: Independent from underlying cli provider (but still possible to hook into via `context.cli`)
* Cons: Doesn't allow to add multiple commands (which is actually a good thing in a way)