### PR TITLE
fix: set `rootDir` token to workspace root

### DIFF
--- a/packages/spire/lib/create-resolver.js
+++ b/packages/spire/lib/create-resolver.js
@@ -9,7 +9,13 @@ function createResolver(context, core) {
       typeof entryPathOrFn === 'string'
         ? requireFrom(
             context.cwd,
-            entryPathOrFn.replace(/<rootDir>/g, context.cwd)
+            entryPathOrFn.replace(
+              /<rootDir>/g,
+              // `INIT_CWD` is set by both npm and yarn, which represent an actual path
+              // where the command was executed from. We'll use it if set to properly
+              // resolve workspace root.
+              context.env.INIT_CWD || context.cwd
+            )
           )
         : entryPathOrFn;
     validatePlugin(createEntry);

--- a/packages/spire/tests/config.spec.js
+++ b/packages/spire/tests/config.spec.js
@@ -38,7 +38,7 @@ describe('spire', () => {
       'package.json': JSON.stringify({
         name: 'spire-test-config',
         spire: {
-          extends: '<rootDir>/spire-config-baz.js',
+          extends: './spire-config-baz.js',
         },
       }),
     });

--- a/packages/spire/tests/hooks.spec.js
+++ b/packages/spire/tests/hooks.spec.js
@@ -34,7 +34,7 @@ describe('spire', () => {
       'package.json': JSON.stringify({
         name: 'spire-test-hooks',
         spire: {
-          extends: '<rootDir>/spire-config.js',
+          extends: './spire-config.js',
         },
       }),
     });


### PR DESCRIPTION
After digging Jest's docs, I found that their `<rootDir>` token behaves that way. I think we can adopt the same behavior with low risk for existing projects using Spire. 

@Rendez please let me know wdyt

Fixes #16 