### PR TITLE
feat(plugin-prettier): autoset prettier config for eslint & ide integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
       "spire-plugin-yarn",
       "spire-plugin-lerna-release"
     ]
-  }
+  },
+  "prettier": "spire-plugin-prettier/config"
 }

--- a/packages/spire-plugin-prettier/README.md
+++ b/packages/spire-plugin-prettier/README.md
@@ -27,6 +27,13 @@
   - `allowCustomConfig` \<boolean\> Whether to allow user-provided config. If
     this option is `false` and there's custom prettier config found it will
     throw an error. Defaults to `true`.
+  - `autosetPrettierConfig` \<boolean\> Whether to automatically set Prettier
+    config in `package.json` on install or not. Defaults to `true`. _Note_: this
+    is essential step for eslint-plugin-prettier and IDE integrations. You can
+    also use `prettier.config.js` to re-export & modify target config, although
+    not recommended. Prefer
+    [`prettier` prop](https://prettier.io/docs/en/configuration.html#sharing-configurations)
+    when possible.
   - `prettierIgnore` \<string\> Path to default `.prettierignore`. Defaults to
     `.gitignore`
   - `allowCustomIgnore` \<boolean\> Whether to allow user-provided

--- a/packages/spire-plugin-prettier/index.js
+++ b/packages/spire-plugin-prettier/index.js
@@ -2,32 +2,58 @@ const execa = require('execa');
 const SpireError = require('spire/error');
 
 function prettier(
-  { hasFile, hasPackageProp, setState, getState },
+  {
+    hasFile,
+    hasPackageProp,
+    getPackageProp,
+    setPackageProp,
+    setState,
+    getState,
+  },
   {
     command = 'format',
-    config: defaultPrettierConfig = require.resolve(
-      'spire-plugin-prettier/config'
-    ),
+    config: defaultPrettierConfig = 'spire-plugin-prettier/config',
+    autosetPrettierConfig = true,
     allowCustomConfig = true,
     prettierIgnore: defaultPrettierIgnore = '.gitignore',
     allowCustomIgnore = true,
     glob = '**/*.+(js|json|less|css|ts|tsx|md)',
   }
 ) {
+  async function hasCustomPrettierConfig() {
+    return (
+      (await hasFile('.prettierrc')) ||
+      (await hasFile('.prettierrc.js')) ||
+      (await hasFile('.prettierrc.json')) ||
+      (await hasFile('.prettierrc.yaml')) ||
+      (await hasFile('.prettierrc.yml')) ||
+      (await hasFile('.prettierrc.toml')) ||
+      (await hasFile('prettier.config.js')) ||
+      (await hasPackageProp('prettier'))
+    );
+  }
   return {
     name: 'spire-plugin-prettier',
     command,
     description: 'format files with Prettier',
+    async postinstall({ logger }) {
+      if (autosetPrettierConfig) {
+        const hasCustomConfig = await hasCustomPrettierConfig();
+        if (hasCustomConfig) {
+          const currentPrettierPkgProp = await getPackageProp('prettier');
+          if (currentPrettierPkgProp !== defaultPrettierConfig) {
+            return logger.warn(
+              'Attempted to set Prettier config but it already exists. Please ensure existing config re-exports `%s`.',
+              defaultPrettierConfig
+            );
+          }
+        }
+        await setPackageProp('prettier', defaultPrettierConfig);
+        await execa('prettier', ['--write', 'package.json']);
+      }
+    },
     async setup({ argv }) {
-      const hasCustomConfig =
-        (await hasFile('.prettierrc')) ||
-        (await hasFile('.prettierrc.js')) ||
-        (await hasFile('.prettierrc.json')) ||
-        (await hasFile('.prettierrc.yaml')) ||
-        (await hasFile('.prettierrc.yml')) ||
-        (await hasFile('.prettierrc.toml')) ||
-        (await hasFile('prettier.config.js')) ||
-        (await hasPackageProp('prettier'));
+      const hasCustomConfig = await hasCustomPrettierConfig();
       const prettierConfig =
         allowCustomConfig && hasCustomConfig
           ? []

--- a/packages/spire/lib/create-core.js
+++ b/packages/spire/lib/create-core.js
@@ -1,18 +1,30 @@
 const { join } = require('path');
-const { pathExists, readJson } = require('fs-extra');
+const { pathExists, readJson, writeJSON } = require('fs-extra');
 
 function createCore({ cwd }, { setState, getState }) {
+  async function hasFile(file) {
+    return await pathExists(join(cwd, file));
+  }
+  async function getPackageProp(prop) {
+    const pkgPath = join(cwd, 'package.json');
+    return await readJson(pkgPath)[prop];
+  }
+  async function hasPackageProp(prop) {
+    return (await getPackageProp(prop)) !== undefined;
+  }
+  async function setPackageProp(prop, value) {
+    const pkgPath = join(cwd, 'package.json');
+    const currentContents = await readJson(pkgPath);
+    const nextContents = { ...currentContents, [prop]: value };
+    await writeJSON(pkgPath, nextContents);
+  }
   return {
     setState,
     getState,
-    // Check if project contains specific file
-    async hasFile(file) {
-      return await pathExists(join(cwd, file));
-    },
-    // Check if project's package.json contains specific prop
-    async hasPackageProp(prop) {
-      return (await readJson(join(cwd, 'package.json'))).hasOwnProperty(prop);
-    },
+    hasFile,
+    getPackageProp,
+    hasPackageProp,
+    setPackageProp,
   };
 }
 

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,2 +1,0 @@
-// Keep this file for editor support
-module.exports = require('spire-plugin-prettier/config');


### PR DESCRIPTION
As Prettier recently introduced [sharable configurations](https://prettier.io/docs/en/configuration.html#sharing-configurations), it now allows us to set Prettier config w/o generating an extra config file (and maintaining it). 

This change automatically adds Prettier config to the current project (if not yet set) as it essentially required to properly work with eslint-plugin-prettier and any IDE.

Resolves #9
