### PR TITLE
fix: disable non-interactive mode and github-release by default

### DIFF
--- a/packages/spire-plugin-lerna-release/index.js
+++ b/packages/spire-plugin-lerna-release/index.js
@@ -7,7 +7,7 @@ function lernaRelease(
     gitAuthorName = undefined,
     gitAuthorEmail = undefined,
     allowBranch = 'master',
-    githubRelease = true,
+    githubRelease = false,
     extraArgs = [],
   }
 ) {
@@ -23,7 +23,6 @@ function lernaRelease(
           allowBranch,
           '--github-release',
           githubRelease,
-          '--yes',
           ...extraArgs,
         ],
       });


### PR DESCRIPTION
I was surprise that lerna runs in non-interactive mode by default, when run through spire. This seems highly risky to me, at least I would have liked to check if the correct packages and versions are getting released. (Which wasn't the case when I tried it :/ )

Also the publish failed because I didn't have a GH_TOKEN setup. The github release in my opinion shouldn't be run by default if it needs to be setup first and in most cases the github release should be run by github actions or travis for better automation.

This of course is a breaking change.