### PR TITLE
fix: Do not do Promise.all on already resolved Promises

### DIFF
--- a/packages/spire/index.js
+++ b/packages/spire/index.js
@@ -21,7 +21,6 @@ async function spire({
   const context = { argv, cli, cwd, env, logger };
   const state = createState();
   const core = createCore(context, state);
-  const running = [];
   // Resolve and flattern config
   let config;
   try {
@@ -52,9 +51,7 @@ async function spire({
         // Call the plugin command
         try {
           logger.debug('Running %s.run', plugin.name);
-          const promise = plugin.run({ options, ...context });
-          running.push(promise);
-          await promise;
+          await plugin.run({ options, ...context });
         } catch (error) {
           errors.push(error);
         }
@@ -75,8 +72,6 @@ async function spire({
       return 1;
     }
   }
-  // Wait for commands to finish
-  await Promise.all(running);
   // Run teardown hooks
   for (const plugin of config.plugins) {
     if (plugin.teardown) {


### PR DESCRIPTION
## Summary

We already do `await` on the command. I thought about removing the await, but then we have to change the error handling.

The problem is, that if there are errors, the `Promise.all()` will make nodejs throw an Unhandled rejection.
