### PR TITLE
feat: Add prettier to default eslint config

### DIFF
--- a/packages/spire-plugin-eslint/config.js
+++ b/packages/spire-plugin-eslint/config.js
@@ -1,9 +1,13 @@
 module.exports = {
   parser: 'babel-eslint',
   extends: ['prettier', 'unobtrusive'],
+  plugins: ['prettier'],
   env: {
     es6: true,
     node: true,
+  },
+  rules: {
+    'prettier/prettier': 'error',
   },
   overrides: [
     {

--- a/packages/spire/index.js
+++ b/packages/spire/index.js
@@ -76,7 +76,9 @@ async function spire({
     }
   }
   // Wait for commands to finish
-  await Promise.all(running).catch(() => { /* ignore errors, we already handle them above */});
+  await Promise.all(running).catch(() => {
+    /* ignore errors, we already handle them above */
+  });
   // Run teardown hooks
   for (const plugin of config.plugins) {
     if (plugin.teardown) {

--- a/packages/spire/lib/create-cli.js
+++ b/packages/spire/lib/create-cli.js
@@ -19,11 +19,16 @@ function createCli() {
       default: false,
       group: 'Options',
     })
-    .command('*', '', () => {}, (argv) => {
-      yargs.showHelp();
-      console.error('\nUnknown command: ' + argv._[0]);
-      process.exit(1);
-    })
+    .command(
+      '*',
+      '',
+      () => {},
+      argv => {
+        yargs.showHelp();
+        console.error('\nUnknown command: ' + argv._[0]);
+        process.exit(1);
+      }
+    )
     .demandCommand(1, 'You need to specify at least one command')
     .exitProcess(false);
 }

--- a/packages/spire/lib/plugins/git.js
+++ b/packages/spire/lib/plugins/git.js
@@ -42,7 +42,7 @@ function git(
               'Set `SKIP_PREFLIGHT_CHECK=true` to disable this check,',
               'but be advised that some plugins may fail.\n',
               'Caused by:\n',
-              reason.message
+              reason.message,
             ].join(' ')
           );
         }


### PR DESCRIPTION
BREAKING CHANGE: prettier is enabled in the default eslint config

## Summary

By default prettier isn't enabled right now. I noticed because eslint was not complaining in the spire repo about formatting issues.
