### PR TITLE
write package.json file by default with 2 space indentation

### DIFF
--- a/packages/spire/lib/create-core.js
+++ b/packages/spire/lib/create-core.js
@@ -1,5 +1,6 @@
 const { join } = require('path');
-const { pathExists, readJson, writeJSON } = require('fs-extra');
+const { pathExists, readJson, writeJSON, readFile } = require('fs-extra');
+const detectIndent = require('detect-indent');
 
 function createCore({ cwd }, { setState, getState }) {
   async function hasFile(file) {
@@ -14,9 +15,11 @@ function createCore({ cwd }, { setState, getState }) {
   }
   async function setPackageProp(prop, value) {
     const pkgPath = join(cwd, 'package.json');
-    const currentContents = await readJson(pkgPath);
+    const fileContents = await readFile(pkgPath, 'UTF-8');
+    const spaces = detectIndent(fileContents).indent;
+    const currentContents = JSON.parse(fileContents);
     const nextContents = { ...currentContents, [prop]: value };
-    await writeJSON(pkgPath, nextContents);
+    await writeJSON(pkgPath, nextContents, { spaces });
   }
   return {
     setState,

--- a/packages/spire/package.json
+++ b/packages/spire/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "cosmiconfig": "^6.0.0",
+    "detect-indent": "^6.0.0",
     "fs-extra": "^8.1.0",
     "import-from": "^3.0.0",
     "invariant": "^2.2.4",

--- a/packages/spire/tests/core.spec.js
+++ b/packages/spire/tests/core.spec.js
@@ -1,0 +1,27 @@
+const { createFixture } = require('spire-test-utils');
+const { readFile } = require('fs-extra');
+const { join } = require('path');
+const createCore = require('../lib/create-core');
+
+const getCore = cwd => {
+  return createCore({ cwd: cwd }, { setState: () => {}, getState: () => {} });
+};
+
+describe('spire', () => {
+  test.each(['  ', '    ', '   ', '\t'])(
+    'detects correct indent for "%s"',
+    async indent => {
+      const fixture = await createFixture({
+        'package.json': `{\n${indent}"name": "spire-test-hooks"\n}`,
+      });
+      const { setPackageProp } = getCore(fixture.cwd);
+      await setPackageProp('test', '123');
+      expect(
+        readFile(join(fixture.cwd, 'package.json'), 'UTF-8')
+      ).resolves.toBe(
+        `{\n${indent}"name": "spire-test-hooks",\n${indent}"test": "123"\n}\n`
+      );
+      await fixture.clean();
+    }
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,6 +2690,11 @@ detect-indent@^5.0.0, detect-indent@~5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
+detect-indent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
+  integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"


### PR DESCRIPTION
We do run prettier over package.json in eslint-plugin-prettier, but it probably does not hurt to already output the file a little bit formatted, so that in case if prettier does not work, it is not completely scrambled.